### PR TITLE
페이지 새로고침 시 404 에러가 발생하는 오류 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "predeploy": "npm run build",
-    "deploy": "gh-pages -d build",
+    "deploy": "cp build/index.html build/404.html && gh-pages -d build",
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coffee-and-taste",
   "version": "0.1.0",
-  "homepage": "https://jack-and-whoop.github.io/coffee-and-taste",
+  "homepage": "https://hdpyo.github.io/coffee-and-taste",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.9.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,5 @@
 const path = require('path');
 
-const URL_PATH = '/coffee-and-taste/';
-
 module.exports = {
   mode: 'development',
   entry: path.resolve(__dirname, 'src/index.jsx'),
@@ -46,10 +44,6 @@ module.exports = {
     extensions: ['.js', '.jsx'],
   },
   devServer: {
-    // historyApiFallback: true, // * 이렇게 설정해봤는데, 새로고침하면 404 가 발생한다.
-    historyApiFallback: {
-      index: `${URL_PATH}index.html`,
-    },
-    publicPath: URL_PATH,
+    historyApiFallback: true,
   },
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,7 @@
 const path = require('path');
 
+const URL_PATH = '/coffee-and-taste/';
+
 module.exports = {
   mode: 'development',
   entry: path.resolve(__dirname, 'src/index.jsx'),
@@ -44,8 +46,10 @@ module.exports = {
     extensions: ['.js', '.jsx'],
   },
   devServer: {
+    // historyApiFallback: true, // * 이렇게 설정해봤는데, 새로고침하면 404 가 발생한다.
     historyApiFallback: {
-      index: 'index.html',
+      index: `${URL_PATH}index.html`,
     },
+    publicPath: URL_PATH,
   },
 };


### PR DESCRIPTION
### 작업 내역
- ~~웹팩 설정 파일에서 historyApiFallback 옵션을 수정했다.~~
  - 해당 옵션은 그냥 true 로만 설정해도 된다.

- 프로젝트 빌드 시 index.html 을 404.html 로 복사하도록 package.json 을 수정한다.

### 데모 링크
- [데모 링크](https://hdpyo.github.io/coffee-and-taste/)

### 참고 자료
- [react-router-dom 404 historyApiFallBack](https://kkj6670.github.io/board/react/historyApiFallBack)
- [[React] gh-pages로 배포한 페이지가 새로고침 시 404 에러가 떠요!](https://bum-developer.tistory.com/entry/React-gh-pages%EB%A1%9C-%EB%B0%B0%ED%8F%AC%ED%95%9C-%ED%8E%98%EC%9D%B4%EC%A7%80%EA%B0%80-%EC%83%88%EB%A1%9C%EA%B3%A0%EC%B9%A8-%EC%8B%9C-404-%EC%97%90%EB%9F%AC%EA%B0%80-%EB%96%A0%EC%9A%94)