### PR TITLE
[리팩토링] 선택된 카테고리를 표시하는 스타일을 추가합니다.

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,7 +13,9 @@ import MenuListContainer from './MenuListContainer';
 import MenuDetailContainer from './MenuDetailContainer';
 import LoginPage from './LoginPage';
 
-import { loadCategories } from './store';
+import { loadCategories, selectCategory } from './store';
+
+import { DEFAULT_SELECTED_CATEGORY_IS_NONE } from './constants';
 
 import logo from './images/logo.png';
 
@@ -58,11 +60,15 @@ export default function App() {
     dispatch(loadCategories());
   }, []);
 
+  const resetSelectedCategory = () => {
+    dispatch(selectCategory(DEFAULT_SELECTED_CATEGORY_IS_NONE));
+  };
+
   return (
     <BrowserRouter basename={process.env.PUBLIC_URL}>
       <Header>
         <LogoContainer>
-          <Link to="/">
+          <Link to="/" onClick={resetSelectedCategory}>
             <Logo src={logo} alt="coffee-and-taste logo" />
           </Link>
         </LogoContainer>

--- a/src/CategoryContainer.jsx
+++ b/src/CategoryContainer.jsx
@@ -4,8 +4,6 @@ import { useSelector } from 'react-redux';
 
 import { Link } from 'react-router-dom';
 
-import { useState } from 'react';
-
 const CategoryContainerStyle = styled.div({
   margin: '0 auto',
   width: '40%',
@@ -36,18 +34,14 @@ const Category = styled.div(
 
 export default function CategoryContainer() {
   const categories = useSelector((state) => state.categories);
-
-  const [activeCategory, setActiveCategory] = useState(0);
+  const selectedCategory = useSelector((state) => state.selectedCategory);
 
   return (
     <CategoryContainerStyle>
       {
         categories.map(({ id, name }) => (
-          <Link
-            to={`/categories/${id}/menu-groups`}
-            onClick={() => setActiveCategory(id)}
-          >
-            <Category key={id} active={activeCategory === id}>
+          <Link to={`/categories/${id}/menu-groups`}>
+            <Category key={id} active={selectedCategory === id}>
               {name}
             </Category>
           </Link>

--- a/src/MenuGroupContainer.jsx
+++ b/src/MenuGroupContainer.jsx
@@ -14,7 +14,7 @@ export default function MenuGroupContainer() {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    dispatch(selectCategory({ categoryId }));
+    dispatch(selectCategory(Number(categoryId)));
     dispatch(loadMenuGroups(categoryId));
   }, [categoryId]);
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,3 @@
+export const DEFAULT_SELECTED_CATEGORY_IS_NONE = 0;
+
+export const DELETE_IT = 0; // TODO : export default 를 막기 위해 적은 임시 변수 (나중에 지우세요.)

--- a/src/store.js
+++ b/src/store.js
@@ -10,7 +10,7 @@ import {
   fetchCategories, fetchMenu, fetchMenuGroups, fetchMenus, postLogin,
 } from './services/api';
 
-const DEFAULT_CATEGORY_IS_BEVERAGE = 1;
+import { DEFAULT_SELECTED_CATEGORY_IS_NONE } from './constants';
 
 // - 초기 상태 값
 const initialState = {
@@ -18,7 +18,7 @@ const initialState = {
   menuGroups: [],
   menus: [],
   menu: {},
-  selectedCategory: DEFAULT_CATEGORY_IS_BEVERAGE,
+  selectedCategory: DEFAULT_SELECTED_CATEGORY_IS_NONE,
   loginFields: {
     email: '',
     password: '',


### PR DESCRIPTION
## 작업 내용

### 변경 전
- '선택된 카테고리' 를 별도의 useState 를 선언하여 상태 관리하여, 카테고리가 클릭될 때마다 해당 상태 값을 변경하는 방식으로 구현.
- 다른 카테고리를 클릭한 뒤 로고를 클릭하면 기존에 표시된 '선택된 카테고리'의 스타일이 그대로 남아있는 문제가 있었다.

### 변경 후
- 사용중인 리덕스 상태 중 selectedCategory 라는 상태 값이 있다.
- 카테고리를 클릭할 때마다 해당 상태 값이 변경되도록 이미 구현을 했었다.
이를 이용해서 별도의 useState 를 사용하지 않고, selectedCategory 와 카테고리 id 를 비교하여 더 간결하게 구현할 수 있었다.
- 로고를 클릭하면 selectedCategory 상태 값을 0으로 초기화하도록 했으며, 0은 매직 넘버이므로 상수로 선언하였다.

