### PR TITLE
기능 추가 : 장바구니에 담긴 메뉴들을 주문하기 

### DIFF
--- a/src/CartContainer.jsx
+++ b/src/CartContainer.jsx
@@ -9,7 +9,7 @@ export default function CartContainer() {
 
   useEffect(() => {
     dispatch(loadCart());
-  });
+  }, []);
 
   const cartMenus = useSelector((state) => state.cartMenus);
 

--- a/src/CartContainer.jsx
+++ b/src/CartContainer.jsx
@@ -32,6 +32,16 @@ export default function CartContainer() {
     dispatch(requestOrder());
   };
 
+  if (cartMenus.length === 0) {
+    return (
+      <div>
+        <h1>Cart</h1>
+        <hr />
+        <div>장바구니에 담긴 메뉴가 없습니다!</div>
+      </div>
+    );
+  }
+
   return (
     <div>
       <h1>Cart</h1>

--- a/src/CartContainer.jsx
+++ b/src/CartContainer.jsx
@@ -2,7 +2,9 @@ import { useEffect } from 'react';
 
 import { useDispatch, useSelector } from 'react-redux';
 
-import { loadCart, addCheckedCartItem, removeUncheckedCartItem } from './store';
+import {
+  loadCart, addCheckedCartItem, removeUncheckedCartItem, requestOrder,
+} from './store';
 
 export default function CartContainer() {
   const dispatch = useDispatch();
@@ -27,7 +29,7 @@ export default function CartContainer() {
   };
 
   const handleClickOrder = () => {
-    // TODO : 주문 api 요청
+    dispatch(requestOrder());
   };
 
   return (

--- a/src/CartContainer.jsx
+++ b/src/CartContainer.jsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 
 import { useDispatch, useSelector } from 'react-redux';
 
-import { loadCart } from './store';
+import { loadCart, addCheckedCartItem, removeUncheckedCartItem } from './store';
 
 export default function CartContainer() {
   const dispatch = useDispatch();
@@ -13,17 +13,38 @@ export default function CartContainer() {
 
   const cartMenus = useSelector((state) => state.cartMenus);
 
+  const checkedItemHandler = (isChecked, checkedItemId) => {
+    if (isChecked) {
+      dispatch(addCheckedCartItem(checkedItemId));
+    } else if (!isChecked) {
+      dispatch(removeUncheckedCartItem(checkedItemId));
+    }
+  };
+
+  const handleChange = (event) => {
+    const { checked, value } = event.target;
+    checkedItemHandler(checked, value);
+  };
+
+  const handleClickOrder = () => {
+    // TODO : 주문 api 요청
+  };
+
   return (
     <div>
       <h1>Cart</h1>
       <hr />
+      <button type="button" onClick={handleClickOrder}>주문하기</button>
       {
         cartMenus.map(({
+          id,
           menu: {
             name, englishName, price, imagePath,
-          }, quantity,
+          },
+          quantity,
         }) => (
           <div>
+            <input type="checkbox" name="menuId" value={id} onChange={handleChange} />
             <span>
               메뉴 이름 :
               {name}

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -66,3 +66,20 @@ export async function postLogin({ email, password }) {
   const { accessToken } = await response.json();
   return accessToken;
 }
+
+export async function postOrder({ accessToken, checkedCartItems }) {
+  const url = `${BASE_URL}/cart/order`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({
+      cartMenuIds: checkedCartItems,
+    }),
+  });
+
+  const data = await response.json();
+  return data;
+}

--- a/src/store.js
+++ b/src/store.js
@@ -34,6 +34,7 @@ const initialState = {
     birthDate: '',
   },
   cartMenus: [],
+  checkedCartItems: [],
 };
 
 // - 액션 생성 함수 정의
@@ -48,6 +49,8 @@ const LOGOUT = 'LOGOUT';
 const CLEAR_LOGIN_FIELDS = 'CLEAR_LOGIN_FIELDS';
 const UPDATE_SIGNUP_FIELDS = 'UPDATE_SIGNUP_FIELDS';
 const SET_CART_MENUS = 'SET_CART_MENUS';
+const ADD_CHECKED_CART_ITEM = 'ADD_CHECKED_CART_ITEM';
+const REMOVE_UNCHECKED_CART_ITEM = 'REMOVE_UNCHECKED_CART_ITEM';
 
 export function updateLoginFields({ name, value }) {
   return {
@@ -153,6 +156,20 @@ export function setCartMenus(cartMenus) {
   return {
     type: SET_CART_MENUS,
     payload: { cartMenus },
+  };
+}
+
+export function addCheckedCartItem(checkedMenuId) {
+  return {
+    type: ADD_CHECKED_CART_ITEM,
+    payload: { checkedMenuId },
+  };
+}
+
+export function removeUncheckedCartItem(uncheckedMenuId) {
+  return {
+    type: REMOVE_UNCHECKED_CART_ITEM,
+    payload: { uncheckedMenuId },
   };
 }
 
@@ -286,6 +303,24 @@ function reducer(state = initialState, action = {}) {
     return {
       ...state,
       cartMenus: action.payload.cartMenus,
+    };
+  }
+
+  if (action.type === ADD_CHECKED_CART_ITEM) {
+    return {
+      ...state,
+      checkedCartItems: [
+        ...state.checkedCartItems, action.payload.checkedMenuId,
+      ],
+    };
+  }
+
+  if (action.type === REMOVE_UNCHECKED_CART_ITEM) {
+    return {
+      ...state,
+      checkedCartItems: [
+        ...state.checkedCartItems.filter((item) => item !== action.payload.uncheckedMenuId),
+      ],
     };
   }
 


### PR DESCRIPTION
## 작업 내역 
- 장바구니에 담긴 메뉴마다 체크박스 생성
- 체크박스 여부에 따라 주문을 요청할 메뉴 상태 변경
(체크O:주문할 메뉴, 체크X: 주문에서 제외할 메뉴)
- 주문할 항목을 체크하고 [주문하기] 버튼을 클릭하면 주문 api 호출

## 보완할 사항
- 주문 요청 후 응답에 따라서 사용자에게 안내하기 (ex. 주문이 완료되었습니다.)

## 기타
- Q1.
장바구니에서 주문할 메뉴를 "선택할 때마다" 상태값을 저장하는 것이 좋을지,
아니면 주문할 때 "선택된 항목들을 한 번에 확인"하는 방식이 좋을지?
  - 주문 api 에 전달할 메뉴들도 따로 상태 관리를 하는 것이 효율적인가?
      --> 주문 시점에서 체크된 항목들을 확인하고 배열로 담아서 api 호출 시에 전달하면 되지 않을까?