### PR TITLE
기능 추가 : 장바구니

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "emotion-reset": "^3.0.1",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
+        "react-icons": "^4.4.0",
         "react-redux": "^8.0.2",
         "react-router-dom": "^6.3.0",
         "react-scripts": "5.0.1",
@@ -14283,6 +14284,14 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
     },
+    "node_modules/react-icons": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.4.0.tgz",
+      "integrity": "sha512-fSbvHeVYo/B5/L4VhB7sBA1i2tS8MkT0Hb9t2H1AVPkwGfVHLJCqyr2Py9dKMxsyM63Eng1GkdZfbWj+Fmv8Rg==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -27598,6 +27607,12 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
+    },
+    "react-icons": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.4.0.tgz",
+      "integrity": "sha512-fSbvHeVYo/B5/L4VhB7sBA1i2tS8MkT0Hb9t2H1AVPkwGfVHLJCqyr2Py9dKMxsyM63Eng1GkdZfbWj+Fmv8Rg==",
+      "requires": {}
     },
     "react-is": {
       "version": "16.13.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "emotion-reset": "^3.0.1",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
+    "react-icons": "^4.4.0",
     "react-redux": "^8.0.2",
     "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.1",

--- a/src/Cart.jsx
+++ b/src/Cart.jsx
@@ -3,6 +3,11 @@ import styled from '@emotion/styled';
 import { BsFillDashCircleFill, BsPlusCircleFill } from 'react-icons/bs';
 import { VscClose } from 'react-icons/vsc';
 
+const CartContainerStyle = styled.div({
+  width: '800px',
+  margin: '0 auto',
+});
+
 const ItemContainer = styled.div({
   border: '1px solid gray',
   margin: '20px 0',
@@ -30,7 +35,7 @@ const CartButtonGroup = styled.div({
 
 const CartItem = styled.div({
   display: 'grid',
-  gridTemplateColumns: '40% auto',
+  gridTemplateColumns: '30% auto',
 });
 
 const CartItemImage = styled.div(
@@ -51,6 +56,8 @@ const CartItemInfo = styled.div({
   justifyContent: 'center',
   alignItems: 'flex-start',
   gap: '15px',
+  width: '80%',
+  margin: '0 auto',
 });
 
 const ItemName = styled.h1({
@@ -76,7 +83,7 @@ const ItemQuantityUl = styled.ul({
   alignContent: 'center',
   '& li': {
     display: 'grid',
-    justifyContent: 'center',
+    justifyContent: 'stretch',
     alignItems: 'center',
     fontSize: '1.7rem',
     lineHeight: '3rem',
@@ -129,7 +136,7 @@ export default function Cart({
   };
 
   return (
-    <>
+    <CartContainerStyle>
       <CartTitle>장바구니</CartTitle>
       <hr />
       {
@@ -176,6 +183,6 @@ export default function Cart({
       <OrderDiv>
         <OrderButton onClick={onClick}>주문하기</OrderButton>
       </OrderDiv>
-    </>
+    </CartContainerStyle>
   );
 }

--- a/src/Cart.jsx
+++ b/src/Cart.jsx
@@ -24,6 +24,17 @@ const CartTitle = styled.h1({
   paddingLeft: '10px',
 });
 
+const CartNoItem = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  alignItems: 'center',
+  height: '300px',
+  '&': {
+    fontSize: '2rem',
+  },
+});
+
 const CartButtonGroup = styled.div({
   display: 'flex',
   justifyContent: 'space-between',
@@ -136,6 +147,18 @@ export default function Cart({
     const { checked, value } = event.target;
     onChange({ checked, value });
   };
+
+  if (cartMenus.length === 0) {
+    return (
+      <CartContainerStyle>
+        <CartTitle>장바구니</CartTitle>
+        <hr />
+        <CartNoItem>
+          장바구니에 담긴 메뉴가 없습니다.
+        </CartNoItem>
+      </CartContainerStyle>
+    );
+  }
 
   return (
     <CartContainerStyle>

--- a/src/Cart.jsx
+++ b/src/Cart.jsx
@@ -99,6 +99,7 @@ const OrderDiv = styled.div({
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',
+  margin: '3rem 0',
 });
 
 const OrderButton = styled.button({

--- a/src/Cart.jsx
+++ b/src/Cart.jsx
@@ -199,6 +199,8 @@ const OrderButton = styled.button({
 export default function Cart({
   cartMenus,
   checkedCartItems,
+  removeSelectedCartItems,
+  removeAllCartItems,
   onChange,
   onClick,
   removeCartItem,
@@ -231,9 +233,13 @@ export default function Cart({
       <CartTitle>장바구니</CartTitle>
       <hr />
       <RemoveButtonDiv>
-        <RemoveSelectedItemsButton>선택 삭제</RemoveSelectedItemsButton>
+        <RemoveSelectedItemsButton onClick={removeSelectedCartItems}>
+          선택 삭제
+        </RemoveSelectedItemsButton>
         <span>|</span>
-        <RemoveAllItemButton>전체 삭제</RemoveAllItemButton>
+        <RemoveAllItemButton onClick={removeAllCartItems}>
+          전체 삭제
+        </RemoveAllItemButton>
       </RemoveButtonDiv>
       {
         cartMenus.map(({

--- a/src/Cart.jsx
+++ b/src/Cart.jsx
@@ -92,11 +92,11 @@ const ItemQuantityUl = styled.ul({
   listStyle: 'none',
   width: '100%',
   display: 'grid',
-  gridTemplateColumns: 'repeat(3, 1fr) 3fr',
+  gridTemplateColumns: '1fr 1fr 1fr 2fr 2fr',
   alignContent: 'center',
   '& li': {
     display: 'grid',
-    justifyContent: 'stretch',
+    justifyContent: 'center',
     alignItems: 'center',
     fontSize: '1.7rem',
     lineHeight: '3rem',
@@ -199,12 +199,21 @@ export default function Cart({
                   <li>
                     <button type="button" onClick={() => updateItemQuantity(id)}>변경</button>
                   </li>
+                  <li>
+                    <span>{quantity * price}</span>
+                  </li>
                 </ItemQuantityUl>
               </CartItemInfo>
             </CartItem>
           </ItemContainer>
         ))
       }
+      <div>
+        총 결제 금액:
+        {' '}
+        <span>0</span>
+        원
+      </div>
       <OrderDiv>
         <OrderButton onClick={onClick}>주문하기</OrderButton>
       </OrderDiv>

--- a/src/Cart.jsx
+++ b/src/Cart.jsx
@@ -144,6 +144,8 @@ export default function Cart({
   decreaseQuantityOne,
   updateItemQuantity,
 }) {
+  let totalPayment = 0;
+
   const handleChange = (event) => {
     const { checked, value } = event.target;
     onChange({ checked, value });
@@ -161,8 +163,6 @@ export default function Cart({
     );
   }
 
-  let totalPayment = 0;
-
   return (
     <CartContainerStyle>
       <CartTitle>장바구니</CartTitle>
@@ -175,11 +175,8 @@ export default function Cart({
           },
           quantity,
         }) => {
-          let isChecked = false;
-
           if (checkedCartItems.includes(String(id))) {
             totalPayment += (price * quantity);
-            isChecked = !isChecked;
           }
 
           return (
@@ -191,7 +188,6 @@ export default function Cart({
                     name="menuId"
                     value={id}
                     onChange={handleChange}
-                    checked={isChecked ? true : null}
                   />
                   <VscClose size="45" cursor="pointer" onClick={() => removeCartItem(id)} />
                 </CartButtonGroup>

--- a/src/Cart.jsx
+++ b/src/Cart.jsx
@@ -69,13 +69,29 @@ const ItemPrice = styled.h3({
 });
 
 const ItemQuantityUl = styled.ul({
-  display: 'flex',
-  justifyContent: 'center',
-  alignItems: 'center',
   listStyle: 'none',
+  width: '100%',
+  display: 'grid',
+  gridTemplateColumns: 'repeat(3, 1fr) 3fr',
+  alignContent: 'center',
   '& li': {
-    fontSize: '1.5rem',
-    paddingRight: '1rem',
+    display: 'grid',
+    justifyContent: 'center',
+    alignItems: 'center',
+    fontSize: '1.7rem',
+    lineHeight: '3rem',
+    '& button': {
+      width: '5rem',
+      height: '2rem',
+      color: 'white',
+      borderRadius: '30px',
+      backgroundColor: '#006633',
+      outline: 'none',
+      border: 'none',
+      cursor: 'pointer',
+      fontSize: '1rem',
+      lineHeight: '1.5rem',
+    },
   },
 });
 
@@ -85,17 +101,15 @@ const OrderDiv = styled.div({
   alignItems: 'center',
 });
 
-const OrderButton = styled.div({
-  display: 'flex',
-  justifyContent: 'center',
-  alignItems: 'center',
+const OrderButton = styled.button({
   width: '70%',
-  height: '2.5rem',
+  height: '3rem',
   fontSize: '1.3rem',
   color: 'white',
   borderRadius: '30px',
   backgroundColor: '#006633',
-  padding: '0.5rem',
+  outline: 'none',
+  border: 'none',
   cursor: 'pointer',
 });
 
@@ -142,9 +156,14 @@ export default function Cart({
                   <li>
                     <BsFillDashCircleFill onClick={() => decreaseQuantityOne(id)} cursor="pointer" />
                   </li>
-                  <li>{quantity}</li>
+                  <li>
+                    <span>{quantity}</span>
+                  </li>
                   <li>
                     <BsPlusCircleFill onClick={() => increaseQuantityOne(id)} cursor="pointer" />
+                  </li>
+                  <li>
+                    <button type="button">변경</button>
                   </li>
                 </ItemQuantityUl>
               </CartItemInfo>

--- a/src/Cart.jsx
+++ b/src/Cart.jsx
@@ -1,0 +1,154 @@
+import styled from '@emotion/styled';
+
+import { BsFillDashCircleFill, BsPlusCircleFill } from 'react-icons/bs';
+import { VscClose } from 'react-icons/vsc';
+
+const ItemContainer = styled.div({
+  border: '1px solid gray',
+  margin: '20px 0',
+});
+
+const CartTitle = styled.h1({
+  fontSize: '2rem',
+  fontWeight: 'bold',
+  color: 'white',
+  backgroundColor: '#321414',
+  lineHeight: '4rem',
+  paddingLeft: '10px',
+});
+
+const CartButtonGroup = styled.div({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  '& input[type=checkbox]': {
+    width: '35px',
+    height: '35px',
+    cursor: 'pointer',
+  },
+});
+
+const CartItem = styled.div({
+  display: 'grid',
+  gridTemplateColumns: '40% auto',
+});
+
+const CartItemImage = styled.div(
+  ({ url }) => ({
+    margin: '30px auto',
+    borderRadius: '50%',
+    width: '150px',
+    height: '150px',
+    ...(url && {
+      background: `url("https://coffee-and-taste.kro.kr${url}") center/100% no-repeat`,
+    }),
+  }),
+);
+
+const CartItemInfo = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  alignItems: 'flex-start',
+  gap: '15px',
+});
+
+const ItemName = styled.h1({
+  fontSize: '1.5rem',
+  fontWeight: '600',
+});
+
+const ItemEnglishName = styled.h2({
+  fontSize: '1.1rem',
+  fontWeight: '350',
+  color: 'rgba(179, 179, 179)',
+});
+
+const ItemPrice = styled.h3({
+  fontSize: '1.3rem',
+});
+
+const ItemQuantityUl = styled.ul({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  listStyle: 'none',
+  '& li': {
+    fontSize: '1.5rem',
+    paddingRight: '1rem',
+  },
+});
+
+const OrderDiv = styled.div({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+});
+
+const OrderButton = styled.div({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  width: '70%',
+  height: '2.5rem',
+  fontSize: '1.3rem',
+  color: 'white',
+  borderRadius: '30px',
+  backgroundColor: '#006633',
+  padding: '0.5rem',
+  cursor: 'pointer',
+});
+
+export default function Cart({ cartMenus, onChange, onClick }) {
+  const handleChange = (event) => {
+    const { checked, value } = event.target;
+    onChange({ checked, value });
+  };
+
+  const handleClickRemoveItem = () => {
+    // TODO : 선택한 메뉴를 장바구니에서 제거하는 api 호출
+    alert('해당 기능은 준비중입니다.');
+  };
+
+  return (
+    <>
+      <CartTitle>장바구니</CartTitle>
+      <hr />
+      {
+        cartMenus.map(({
+          id,
+          menu: {
+            name, englishName, price, imagePath,
+          },
+          quantity,
+        }) => (
+          <ItemContainer>
+            <CartButtonGroup>
+              <input type="checkbox" name="menuId" value={id} onChange={handleChange} />
+              <VscClose size="45" cursor="pointer" onClick={handleClickRemoveItem} />
+            </CartButtonGroup>
+            <CartItem>
+              <CartItemImage url={imagePath} />
+              <CartItemInfo>
+                <ItemName>{name}</ItemName>
+                <ItemEnglishName>{englishName}</ItemEnglishName>
+                <ItemPrice>
+                  {price ? price.toLocaleString('ko-KR') : null}
+                  원
+                </ItemPrice>
+                <ItemQuantityUl>
+                  <li><BsFillDashCircleFill cursor="pointer" /></li>
+                  <li>{quantity}</li>
+                  <li><BsPlusCircleFill cursor="pointer" /></li>
+                </ItemQuantityUl>
+              </CartItemInfo>
+            </CartItem>
+          </ItemContainer>
+        ))
+      }
+      <OrderDiv>
+        <OrderButton onClick={onClick}>주문하기</OrderButton>
+      </OrderDiv>
+    </>
+  );
+}

--- a/src/Cart.jsx
+++ b/src/Cart.jsx
@@ -145,6 +145,7 @@ export default function Cart({
   updateItemQuantity,
 }) {
   let totalPayment = 0;
+  let totalQuantity = 0;
 
   const handleChange = (event) => {
     const { checked, value } = event.target;
@@ -177,6 +178,7 @@ export default function Cart({
         }) => {
           if (checkedCartItems.includes(String(id))) {
             totalPayment += (price * quantity);
+            totalQuantity += quantity;
           }
 
           return (
@@ -227,6 +229,12 @@ export default function Cart({
           );
         })
       }
+      <div>
+        총
+        {' '}
+        {totalQuantity}
+        개
+      </div>
       <div>
         총 결제 금액 :
         {' '}

--- a/src/Cart.jsx
+++ b/src/Cart.jsx
@@ -114,7 +114,7 @@ const OrderButton = styled.button({
 });
 
 export default function Cart({
-  cartMenus, onChange, onClick, increaseQuantityOne, decreaseQuantityOne,
+  cartMenus, onChange, onClick, increaseQuantityOne, decreaseQuantityOne, updateItemQuantity,
 }) {
   const handleChange = (event) => {
     const { checked, value } = event.target;
@@ -163,7 +163,7 @@ export default function Cart({
                     <BsPlusCircleFill onClick={() => increaseQuantityOne(id)} cursor="pointer" />
                   </li>
                   <li>
-                    <button type="button">변경</button>
+                    <button type="button" onClick={() => updateItemQuantity(id)}>변경</button>
                   </li>
                 </ItemQuantityUl>
               </CartItemInfo>

--- a/src/Cart.jsx
+++ b/src/Cart.jsx
@@ -99,7 +99,9 @@ const OrderButton = styled.div({
   cursor: 'pointer',
 });
 
-export default function Cart({ cartMenus, onChange, onClick }) {
+export default function Cart({
+  cartMenus, onChange, onClick, increaseQuantityOne, decreaseQuantityOne,
+}) {
   const handleChange = (event) => {
     const { checked, value } = event.target;
     onChange({ checked, value });
@@ -136,10 +138,14 @@ export default function Cart({ cartMenus, onChange, onClick }) {
                   {price ? price.toLocaleString('ko-KR') : null}
                   원
                 </ItemPrice>
-                <ItemQuantityUl>
-                  <li><BsFillDashCircleFill cursor="pointer" /></li>
+                <ItemQuantityUl id={id}>
+                  <li>
+                    <BsFillDashCircleFill onClick={() => decreaseQuantityOne(id)} cursor="pointer" />
+                  </li>
                   <li>{quantity}</li>
-                  <li><BsPlusCircleFill cursor="pointer" /></li>
+                  <li>
+                    <BsPlusCircleFill onClick={() => increaseQuantityOne(id)} cursor="pointer" />
+                  </li>
                 </ItemQuantityUl>
               </CartItemInfo>
             </CartItem>

--- a/src/Cart.jsx
+++ b/src/Cart.jsx
@@ -136,6 +136,7 @@ const OrderButton = styled.button({
 
 export default function Cart({
   cartMenus,
+  checkedCartItems,
   onChange,
   onClick,
   removeCartItem,
@@ -160,6 +161,8 @@ export default function Cart({
     );
   }
 
+  let totalPayment = 0;
+
   return (
     <CartContainerStyle>
       <CartTitle>장바구니</CartTitle>
@@ -171,47 +174,67 @@ export default function Cart({
             name, englishName, price, imagePath,
           },
           quantity,
-        }) => (
-          <ItemContainer>
-            <CartButtonGroup>
-              <input type="checkbox" name="menuId" value={id} onChange={handleChange} />
-              <VscClose size="45" cursor="pointer" onClick={() => removeCartItem(id)} />
-            </CartButtonGroup>
-            <CartItem>
-              <CartItemImage url={imagePath} />
-              <CartItemInfo>
-                <ItemName>{name}</ItemName>
-                <ItemEnglishName>{englishName}</ItemEnglishName>
-                <ItemPrice>
-                  {price ? price.toLocaleString('ko-KR') : null}
-                  원
-                </ItemPrice>
-                <ItemQuantityUl id={id}>
-                  <li>
-                    <BsFillDashCircleFill onClick={() => decreaseQuantityOne(id)} cursor="pointer" />
-                  </li>
-                  <li>
-                    <span>{quantity}</span>
-                  </li>
-                  <li>
-                    <BsPlusCircleFill onClick={() => increaseQuantityOne(id)} cursor="pointer" />
-                  </li>
-                  <li>
-                    <button type="button" onClick={() => updateItemQuantity(id)}>변경</button>
-                  </li>
-                  <li>
-                    <span>{quantity * price}</span>
-                  </li>
-                </ItemQuantityUl>
-              </CartItemInfo>
-            </CartItem>
-          </ItemContainer>
-        ))
+        }) => {
+          let isChecked = false;
+
+          if (checkedCartItems.includes(String(id))) {
+            totalPayment += (price * quantity);
+            isChecked = !isChecked;
+          }
+
+          return (
+            (
+              <ItemContainer>
+                <CartButtonGroup>
+                  <input
+                    type="checkbox"
+                    name="menuId"
+                    value={id}
+                    onChange={handleChange}
+                    checked={isChecked ? true : null}
+                  />
+                  <VscClose size="45" cursor="pointer" onClick={() => removeCartItem(id)} />
+                </CartButtonGroup>
+                <CartItem>
+                  <CartItemImage url={imagePath} />
+                  <CartItemInfo>
+                    <ItemName>{name}</ItemName>
+                    <ItemEnglishName>{englishName}</ItemEnglishName>
+                    <ItemPrice>
+                      {price ? price.toLocaleString('ko-KR') : null}
+                      원
+                    </ItemPrice>
+                    <ItemQuantityUl id={id}>
+                      <li>
+                        <BsFillDashCircleFill onClick={() => decreaseQuantityOne(id)} cursor="pointer" />
+                      </li>
+                      <li>
+                        <span>{quantity}</span>
+                      </li>
+                      <li>
+                        <BsPlusCircleFill onClick={() => increaseQuantityOne(id)} cursor="pointer" />
+                      </li>
+                      <li>
+                        <button type="button" onClick={() => updateItemQuantity(id)}>변경</button>
+                      </li>
+                      <li>
+                        <span>
+                          {(quantity * price).toLocaleString('ko-KR')}
+                          원
+                        </span>
+                      </li>
+                    </ItemQuantityUl>
+                  </CartItemInfo>
+                </CartItem>
+              </ItemContainer>
+            )
+          );
+        })
       }
       <div>
-        총 결제 금액:
+        총 결제 금액 :
         {' '}
-        <span>0</span>
+        <span>{totalPayment.toLocaleString('ko-KR')}</span>
         원
       </div>
       <OrderDiv>

--- a/src/Cart.jsx
+++ b/src/Cart.jsx
@@ -36,27 +36,30 @@ const CartNoItem = styled.div({
 });
 
 const CartButtonGroup = styled.div({
+  marginTop: '-5px',
   display: 'flex',
   justifyContent: 'space-between',
   alignItems: 'center',
   '& input[type=checkbox]': {
-    width: '35px',
-    height: '35px',
+    width: '30px',
+    height: '30px',
     cursor: 'pointer',
   },
 });
 
 const CartItem = styled.div({
+  marginTop: '-45px',
+  marginBottom: '-10px',
   display: 'grid',
   gridTemplateColumns: '30% auto',
 });
 
 const CartItemImage = styled.div(
   ({ url }) => ({
-    margin: '30px auto',
+    margin: '10px auto',
     borderRadius: '50%',
-    width: '150px',
-    height: '150px',
+    width: '100px',
+    height: '100px',
     ...(url && {
       background: `url("https://coffee-and-taste.kro.kr${url}") center/100% no-repeat`,
     }),
@@ -68,24 +71,24 @@ const CartItemInfo = styled.div({
   flexDirection: 'column',
   justifyContent: 'center',
   alignItems: 'flex-start',
-  gap: '15px',
-  width: '80%',
+  gap: '10px',
+  width: '100%',
   margin: '0 auto',
 });
 
 const ItemName = styled.h1({
-  fontSize: '1.5rem',
+  fontSize: '1.1rem',
   fontWeight: '600',
 });
 
 const ItemEnglishName = styled.h2({
-  fontSize: '1.1rem',
+  fontSize: '1.0rem',
   fontWeight: '350',
   color: 'rgba(179, 179, 179)',
 });
 
 const ItemPrice = styled.h3({
-  fontSize: '1.3rem',
+  fontSize: '1.0rem',
 });
 
 const ItemQuantityUl = styled.ul({
@@ -94,12 +97,23 @@ const ItemQuantityUl = styled.ul({
   display: 'grid',
   gridTemplateColumns: '1fr 1fr 1fr 2fr 2fr',
   alignContent: 'center',
-  '& li': {
+});
+
+const ItemQuantityLi = styled.li(
+  ({ active }) => ({
     display: 'grid',
     justifyContent: 'center',
     alignItems: 'center',
-    fontSize: '1.7rem',
-    lineHeight: '3rem',
+    fontSize: '1.3rem',
+    lineHeight: '2rem',
+    '& svg': {
+      fontSize: '1.7rem',
+      cursor: 'pointer',
+      ...(active && {
+        opacity: '0.5',
+        cursor: 'not-allowed',
+      }),
+    },
     '& button': {
       width: '5rem',
       height: '2rem',
@@ -112,8 +126,8 @@ const ItemQuantityUl = styled.ul({
       fontSize: '1rem',
       lineHeight: '1.5rem',
     },
-  },
-});
+  }),
+);
 
 const OrderDiv = styled.div({
   display: 'flex',
@@ -191,7 +205,7 @@ export default function Cart({
                     value={id}
                     onChange={handleChange}
                   />
-                  <VscClose size="45" cursor="pointer" onClick={() => removeCartItem(id)} />
+                  <VscClose size="30" cursor="pointer" onClick={() => removeCartItem(id)} />
                 </CartButtonGroup>
                 <CartItem>
                   <CartItemImage url={imagePath} />
@@ -202,25 +216,29 @@ export default function Cart({
                       {price ? price.toLocaleString('ko-KR') : null}
                       원
                     </ItemPrice>
-                    <ItemQuantityUl id={id}>
-                      <li>
-                        <BsFillDashCircleFill onClick={() => decreaseQuantityOne(id)} cursor="pointer" />
-                      </li>
-                      <li>
+                    <ItemQuantityUl>
+                      <ItemQuantityLi active={quantity === 1}>
+                        <BsFillDashCircleFill
+                          onClick={() => decreaseQuantityOne(id)}
+                        />
+                      </ItemQuantityLi>
+                      <ItemQuantityLi>
                         <span>{quantity}</span>
-                      </li>
-                      <li>
-                        <BsPlusCircleFill onClick={() => increaseQuantityOne(id)} cursor="pointer" />
-                      </li>
-                      <li>
+                      </ItemQuantityLi>
+                      <ItemQuantityLi>
+                        <BsPlusCircleFill
+                          onClick={() => increaseQuantityOne(id)}
+                        />
+                      </ItemQuantityLi>
+                      <ItemQuantityLi>
                         <button type="button" onClick={() => updateItemQuantity(id)}>변경</button>
-                      </li>
-                      <li>
+                      </ItemQuantityLi>
+                      <ItemQuantityLi>
                         <span>
                           {(quantity * price).toLocaleString('ko-KR')}
                           원
                         </span>
-                      </li>
+                      </ItemQuantityLi>
                     </ItemQuantityUl>
                   </CartItemInfo>
                 </CartItem>

--- a/src/Cart.jsx
+++ b/src/Cart.jsx
@@ -9,8 +9,10 @@ const CartContainerStyle = styled.div({
 });
 
 const ItemContainer = styled.div({
-  border: '1px solid gray',
+  border: '1px solid #e1e1e8',
   margin: '20px 0',
+  borderRadius: '30px',
+  padding: '20px 20px',
 });
 
 const CartTitle = styled.h1({

--- a/src/Cart.jsx
+++ b/src/Cart.jsx
@@ -115,16 +115,17 @@ const OrderButton = styled.button({
 });
 
 export default function Cart({
-  cartMenus, onChange, onClick, increaseQuantityOne, decreaseQuantityOne, updateItemQuantity,
+  cartMenus,
+  onChange,
+  onClick,
+  removeCartItem,
+  increaseQuantityOne,
+  decreaseQuantityOne,
+  updateItemQuantity,
 }) {
   const handleChange = (event) => {
     const { checked, value } = event.target;
     onChange({ checked, value });
-  };
-
-  const handleClickRemoveItem = () => {
-    // TODO : 선택한 메뉴를 장바구니에서 제거하는 api 호출
-    alert('해당 기능은 준비중입니다.');
   };
 
   return (
@@ -142,7 +143,7 @@ export default function Cart({
           <ItemContainer>
             <CartButtonGroup>
               <input type="checkbox" name="menuId" value={id} onChange={handleChange} />
-              <VscClose size="45" cursor="pointer" onClick={handleClickRemoveItem} />
+              <VscClose size="45" cursor="pointer" onClick={() => removeCartItem(id)} />
             </CartButtonGroup>
             <CartItem>
               <CartItemImage url={imagePath} />

--- a/src/Cart.jsx
+++ b/src/Cart.jsx
@@ -8,6 +8,29 @@ const CartContainerStyle = styled.div({
   margin: '0 auto',
 });
 
+const RemoveButtonDiv = styled.div({
+  display: 'flex',
+  justifyContent: 'flex-end',
+  alignItems: 'center',
+});
+
+const RemoveSelectedItemsButton = styled.button({
+  border: 'none',
+  backgroundColor: 'inherit',
+  padding: '10px 15px',
+  color: '#006633',
+  fontSize: '16px',
+  cursor: 'pointer',
+});
+
+const RemoveAllItemButton = styled.button({
+  border: 'none',
+  backgroundColor: 'inherit',
+  padding: '10px 15px',
+  fontSize: '16px',
+  cursor: 'pointer',
+});
+
 const ItemContainer = styled.div({
   border: '1px solid #e1e1e8',
   margin: '20px 0',
@@ -44,6 +67,9 @@ const CartButtonGroup = styled.div({
     width: '30px',
     height: '30px',
     cursor: 'pointer',
+  },
+  '& svg': {
+    zIndex: '1',
   },
 });
 
@@ -129,6 +155,28 @@ const ItemQuantityLi = styled.li(
   }),
 );
 
+const TotalQuantityAndPriceDiv = styled.div({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  marginTop: '1rem',
+});
+
+const TotalQuantityDiv = styled.div({
+  fontSize: '1.5rem',
+  '& span': {
+    color: '#006633',
+    fontWeight: '700',
+  },
+});
+
+const TotalPriceDiv = styled.div({
+  fontSize: '2rem',
+  '& span': {
+    fontWeight: '700',
+  },
+});
+
 const OrderDiv = styled.div({
   display: 'flex',
   justifyContent: 'center',
@@ -182,6 +230,11 @@ export default function Cart({
     <CartContainerStyle>
       <CartTitle>장바구니</CartTitle>
       <hr />
+      <RemoveButtonDiv>
+        <RemoveSelectedItemsButton>선택 삭제</RemoveSelectedItemsButton>
+        <span>|</span>
+        <RemoveAllItemButton>전체 삭제</RemoveAllItemButton>
+      </RemoveButtonDiv>
       {
         cartMenus.map(({
           id,
@@ -205,7 +258,11 @@ export default function Cart({
                     value={id}
                     onChange={handleChange}
                   />
-                  <VscClose size="30" cursor="pointer" onClick={() => removeCartItem(id)} />
+                  <VscClose
+                    size="30"
+                    cursor="pointer"
+                    onClick={() => removeCartItem(id)}
+                  />
                 </CartButtonGroup>
                 <CartItem>
                   <CartItemImage url={imagePath} />
@@ -247,18 +304,19 @@ export default function Cart({
           );
         })
       }
-      <div>
-        총
-        {' '}
-        {totalQuantity}
-        개
-      </div>
-      <div>
-        총 결제 금액 :
-        {' '}
-        <span>{totalPayment.toLocaleString('ko-KR')}</span>
-        원
-      </div>
+      <hr />
+      <TotalQuantityAndPriceDiv>
+        <TotalQuantityDiv>
+          총
+          {' '}
+          <span>{totalQuantity}</span>
+          개
+        </TotalQuantityDiv>
+        <TotalPriceDiv>
+          <span>{totalPayment.toLocaleString('ko-KR')}</span>
+          원
+        </TotalPriceDiv>
+      </TotalQuantityAndPriceDiv>
       <OrderDiv>
         <OrderButton onClick={onClick}>주문하기</OrderButton>
       </OrderDiv>

--- a/src/CartContainer.jsx
+++ b/src/CartContainer.jsx
@@ -3,12 +3,13 @@ import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import {
-  loadCart,
   addCheckedCartItem,
+  cartMenuQuantityMinusOne,
+  cartMenuQuantityPlusOne,
+  loadCart,
   removeUncheckedCartItem,
   requestOrder,
-  cartMenuQuantityPlusOne,
-  cartMenuQuantityMinusOne,
+  requestRemoveCartItem,
   requestUpdateCartItemQuantity,
 } from './store';
 
@@ -17,11 +18,11 @@ import Cart from './Cart';
 export default function CartContainer() {
   const dispatch = useDispatch();
 
+  const cartMenus = useSelector((state) => state.cartMenus);
+
   useEffect(() => {
     dispatch(loadCart());
-  }, []);
-
-  const cartMenus = useSelector((state) => state.cartMenus);
+  }, [dispatch]);
 
   const checkedItemHandler = (isChecked, checkedItemId) => {
     if (isChecked) {
@@ -33,6 +34,10 @@ export default function CartContainer() {
 
   const handleChange = ({ checked, value }) => {
     checkedItemHandler(checked, value);
+  };
+
+  const handleClickRemoveCartItem = (menuId) => {
+    dispatch(requestRemoveCartItem(menuId));
   };
 
   const handleClickOrder = () => {
@@ -48,7 +53,6 @@ export default function CartContainer() {
   };
 
   const handleClickUpdateItemQuantity = (menuId) => {
-    // TODO : 특정 menuId 와 해당 menuId 의 quantity 를 전달하여 수량 업데이트 요청하기
     dispatch(requestUpdateCartItemQuantity(menuId));
   };
 
@@ -67,6 +71,7 @@ export default function CartContainer() {
       cartMenus={cartMenus}
       onChange={handleChange}
       onClick={handleClickOrder}
+      removeCartItem={handleClickRemoveCartItem}
       increaseQuantityOne={handleClickQuantityPlusOne}
       decreaseQuantityOne={handleClickQuantityMinusOne}
       updateItemQuantity={handleClickUpdateItemQuantity}

--- a/src/CartContainer.jsx
+++ b/src/CartContainer.jsx
@@ -55,16 +55,6 @@ export default function CartContainer() {
     dispatch(requestUpdateCartItemQuantity(menuId));
   };
 
-  if (cartMenus.length === 0) {
-    return (
-      <div>
-        <h1>Cart</h1>
-        <hr />
-        <div>장바구니에 담긴 메뉴가 없습니다!</div>
-      </div>
-    );
-  }
-
   return (
     <Cart
       cartMenus={cartMenus}

--- a/src/CartContainer.jsx
+++ b/src/CartContainer.jsx
@@ -6,6 +6,8 @@ import {
   loadCart, addCheckedCartItem, removeUncheckedCartItem, requestOrder,
 } from './store';
 
+import Cart from './Cart';
+
 export default function CartContainer() {
   const dispatch = useDispatch();
 
@@ -23,8 +25,7 @@ export default function CartContainer() {
     }
   };
 
-  const handleChange = (event) => {
-    const { checked, value } = event.target;
+  const handleChange = ({ checked, value }) => {
     checkedItemHandler(checked, value);
   };
 
@@ -43,40 +44,10 @@ export default function CartContainer() {
   }
 
   return (
-    <div>
-      <h1>Cart</h1>
-      <hr />
-      <button type="button" onClick={handleClickOrder}>주문하기</button>
-      {
-        cartMenus.map(({
-          id,
-          menu: {
-            name, englishName, price, imagePath,
-          },
-          quantity,
-        }) => (
-          <div>
-            <input type="checkbox" name="menuId" value={id} onChange={handleChange} />
-            <span>
-              메뉴 이름 :
-              {name}
-            </span>
-            <span>
-              영어 이름 :
-              {englishName}
-            </span>
-            <span>
-              가격 :
-              {price}
-            </span>
-            <span>
-              수량 :
-              {quantity}
-            </span>
-            <img src={`https://coffee-and-taste.kro.kr${imagePath}`} alt={name} />
-          </div>
-        ))
-      }
-    </div>
+    <Cart
+      cartMenus={cartMenus}
+      onChange={handleChange}
+      onClick={handleClickOrder}
+    />
   );
 }

--- a/src/CartContainer.jsx
+++ b/src/CartContainer.jsx
@@ -3,7 +3,12 @@ import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import {
-  loadCart, addCheckedCartItem, removeUncheckedCartItem, requestOrder,
+  loadCart,
+  addCheckedCartItem,
+  removeUncheckedCartItem,
+  requestOrder,
+  cartMenuQuantityPlusOne,
+  cartMenuQuantityMinusOne,
 } from './store';
 
 import Cart from './Cart';
@@ -33,6 +38,14 @@ export default function CartContainer() {
     dispatch(requestOrder());
   };
 
+  const handleClickQuantityPlusOne = (menuId) => {
+    dispatch(cartMenuQuantityPlusOne(menuId));
+  };
+
+  const handleClickQuantityMinusOne = (menuId) => {
+    dispatch(cartMenuQuantityMinusOne(menuId));
+  };
+
   if (cartMenus.length === 0) {
     return (
       <div>
@@ -48,6 +61,8 @@ export default function CartContainer() {
       cartMenus={cartMenus}
       onChange={handleChange}
       onClick={handleClickOrder}
+      increaseQuantityOne={handleClickQuantityPlusOne}
+      decreaseQuantityOne={handleClickQuantityMinusOne}
     />
   );
 }

--- a/src/CartContainer.jsx
+++ b/src/CartContainer.jsx
@@ -9,6 +9,7 @@ import {
   requestOrder,
   cartMenuQuantityPlusOne,
   cartMenuQuantityMinusOne,
+  requestUpdateCartItemQuantity,
 } from './store';
 
 import Cart from './Cart';
@@ -46,6 +47,11 @@ export default function CartContainer() {
     dispatch(cartMenuQuantityMinusOne(menuId));
   };
 
+  const handleClickUpdateItemQuantity = (menuId) => {
+    // TODO : 특정 menuId 와 해당 menuId 의 quantity 를 전달하여 수량 업데이트 요청하기
+    dispatch(requestUpdateCartItemQuantity(menuId));
+  };
+
   if (cartMenus.length === 0) {
     return (
       <div>
@@ -63,6 +69,7 @@ export default function CartContainer() {
       onClick={handleClickOrder}
       increaseQuantityOne={handleClickQuantityPlusOne}
       decreaseQuantityOne={handleClickQuantityMinusOne}
+      updateItemQuantity={handleClickUpdateItemQuantity}
     />
   );
 }

--- a/src/CartContainer.jsx
+++ b/src/CartContainer.jsx
@@ -11,6 +11,8 @@ import {
   clearCheckedCartItems,
   loadCart,
   removeUncheckedCartItem,
+  requestDeleteAllCartItems,
+  requestDeleteSelectedCartItem,
   requestOrder,
   requestRemoveCartItem,
   requestUpdateCartItemQuantity,
@@ -67,10 +69,24 @@ export default function CartContainer() {
       });
   };
 
+  const handleClickDeleteSelectedCartItems = () => {
+    if (window.confirm('선택한 메뉴를 삭제하시겠습니까?')) {
+      dispatch(requestDeleteSelectedCartItem());
+    }
+  };
+
+  const handleClickDeleteAllCartItems = () => {
+    if (window.confirm('전체 메뉴를 삭제하시겠습니까?')) {
+      dispatch(requestDeleteAllCartItems());
+    }
+  };
+
   return (
     <Cart
       cartMenus={cartMenus}
       checkedCartItems={checkedCartItems}
+      removeSelectedCartItems={handleClickDeleteSelectedCartItems}
+      removeAllCartItems={handleClickDeleteAllCartItems}
       onChange={handleChange}
       onClick={handleClickOrder}
       removeCartItem={handleClickRemoveCartItem}

--- a/src/CartContainer.jsx
+++ b/src/CartContainer.jsx
@@ -47,7 +47,9 @@ export default function CartContainer() {
   };
 
   const handleClickRemoveCartItem = (menuId) => {
-    dispatch(requestRemoveCartItem(menuId));
+    if (window.confirm('메뉴를 삭제하시겠습니까?')) {
+      dispatch(requestRemoveCartItem(menuId));
+    }
   };
 
   const handleClickOrder = () => {

--- a/src/CartContainer.jsx
+++ b/src/CartContainer.jsx
@@ -1,7 +1,6 @@
 import { useEffect } from 'react';
 
 import { useDispatch, useSelector } from 'react-redux';
-
 import {
   addCheckedCartItem,
   cartMenuQuantityMinusOne,

--- a/src/CartContainer.jsx
+++ b/src/CartContainer.jsx
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import {
   addCheckedCartItem,
   cartMenuQuantityMinusOne,
-  cartMenuQuantityPlusOne,
+  cartMenuQuantityPlusOne, clearCheckedCartItems,
   loadCart,
   removeUncheckedCartItem,
   requestOrder,
@@ -22,6 +22,7 @@ export default function CartContainer() {
 
   useEffect(() => {
     dispatch(loadCart());
+    dispatch(clearCheckedCartItems());
   }, []);
 
   const checkedItemHandler = (isChecked, checkedItemId) => {

--- a/src/CartContainer.jsx
+++ b/src/CartContainer.jsx
@@ -18,10 +18,11 @@ export default function CartContainer() {
   const dispatch = useDispatch();
 
   const cartMenus = useSelector((state) => state.cartMenus);
+  const checkedCartItems = useSelector((state) => state.checkedCartItems);
 
   useEffect(() => {
     dispatch(loadCart());
-  }, [dispatch]);
+  }, []);
 
   const checkedItemHandler = (isChecked, checkedItemId) => {
     if (isChecked) {
@@ -58,6 +59,7 @@ export default function CartContainer() {
   return (
     <Cart
       cartMenus={cartMenus}
+      checkedCartItems={checkedCartItems}
       onChange={handleChange}
       onClick={handleClickOrder}
       removeCartItem={handleClickRemoveCartItem}

--- a/src/CartContainer.jsx
+++ b/src/CartContainer.jsx
@@ -1,10 +1,14 @@
 import { useEffect } from 'react';
 
 import { useDispatch, useSelector } from 'react-redux';
+
+import { useNavigate } from 'react-router-dom';
+
 import {
   addCheckedCartItem,
   cartMenuQuantityMinusOne,
-  cartMenuQuantityPlusOne, clearCheckedCartItems,
+  cartMenuQuantityPlusOne,
+  clearCheckedCartItems,
   loadCart,
   removeUncheckedCartItem,
   requestOrder,
@@ -14,8 +18,11 @@ import {
 
 import Cart from './Cart';
 
+import { CURRENT_PAGE_RELOAD } from './constants';
+
 export default function CartContainer() {
   const dispatch = useDispatch();
+  const navigate = useNavigate();
 
   const cartMenus = useSelector((state) => state.cartMenus);
   const checkedCartItems = useSelector((state) => state.checkedCartItems);
@@ -54,7 +61,10 @@ export default function CartContainer() {
   };
 
   const handleClickUpdateItemQuantity = (menuId) => {
-    dispatch(requestUpdateCartItemQuantity(menuId));
+    dispatch(requestUpdateCartItemQuantity(menuId))
+      .then(() => {
+        navigate(CURRENT_PAGE_RELOAD);
+      });
   };
 
   return (

--- a/src/MenuDetail.jsx
+++ b/src/MenuDetail.jsx
@@ -85,8 +85,10 @@ export default function MenuDetail({
   }, []);
 
   const handleClickAddToCart = () => {
-    dispatch(requestAddToCart());
-    navigate('/cart');
+    dispatch(requestAddToCart())
+      .then(
+        () => navigate('/cart'),
+      );
   };
 
   const handleClickPlusOne = () => {

--- a/src/MenuDetail.jsx
+++ b/src/MenuDetail.jsx
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
 
+import { BsFillDashCircleFill, BsPlusCircleFill } from 'react-icons/bs';
+
 const MenuImage = styled.div(
   ({ url }) => ({
     margin: '30px auto',
@@ -49,6 +51,16 @@ const CartButton = styled.button({
   padding: '0.5rem',
 });
 
+const MenuQuantity = styled.div({
+  display: 'flex',
+  alignItems: 'center',
+});
+
+const Quantity = styled.span({
+  fontSize: '1.5rem',
+  padding: '0.5rem 1rem',
+});
+
 export default function MenuDetail({
   menu: {
     description, englishName, imagePath, name, price,
@@ -57,6 +69,16 @@ export default function MenuDetail({
   const handleClickAddToCart = () => {
     // TODO : 클릭한 메뉴를 장바구니에 담는 api 호출하기
 
+  };
+
+  const handleClickPlusOne = () => {
+    // TODO : 메뉴 수량 +1
+    alert('handleClickPlusOne');
+  };
+
+  const handleClickMinusOne = () => {
+    // TODO : 메뉴 수량 -1
+    alert('handleClickMinusOne');
   };
 
   return (
@@ -77,8 +99,14 @@ export default function MenuDetail({
         {price ? price.toLocaleString('ko-KR') : null}
         원
       </MenuPrice>
+      <MenuQuantity>
+        <BsFillDashCircleFill size="30" onClick={handleClickMinusOne} />
+        <Quantity>1</Quantity>
+        <BsPlusCircleFill size="30" onClick={handleClickPlusOne} />
+      </MenuQuantity>
       <OrderButton>주문하기</OrderButton>
       <CartButton onClick={handleClickAddToCart}>장바구니에 담기</CartButton>
+
     </>
   );
 }

--- a/src/MenuDetail.jsx
+++ b/src/MenuDetail.jsx
@@ -41,11 +41,24 @@ const OrderButton = styled.button({
   padding: '0.5rem',
 });
 
+const CartButton = styled.button({
+  fontSize: '1.1rem',
+  borderRadius: '10%',
+  color: 'white',
+  backgroundColor: '#006633',
+  padding: '0.5rem',
+});
+
 export default function MenuDetail({
   menu: {
     description, englishName, imagePath, name, price,
   },
 }) {
+  const handleClickAddToCart = () => {
+    // TODO : 클릭한 메뉴를 장바구니에 담는 api 호출하기
+
+  };
+
   return (
     <>
       <MenuImage url={imagePath} />
@@ -65,6 +78,7 @@ export default function MenuDetail({
         원
       </MenuPrice>
       <OrderButton>주문하기</OrderButton>
+      <CartButton onClick={handleClickAddToCart}>장바구니에 담기</CartButton>
     </>
   );
 }

--- a/src/MenuDetail.jsx
+++ b/src/MenuDetail.jsx
@@ -6,6 +6,7 @@ import styled from '@emotion/styled';
 
 import { BsFillDashCircleFill, BsPlusCircleFill } from 'react-icons/bs';
 
+import { useNavigate } from 'react-router-dom';
 import {
   initializeMenuQuantity, menuQuantityMinusOne, menuQuantityPlusOne, requestAddToCart,
 } from './store';
@@ -75,6 +76,7 @@ export default function MenuDetail({
   },
 }) {
   const dispatch = useDispatch();
+  const navigate = useNavigate();
 
   const menuQuantity = useSelector((state) => state.menuQuantity);
 
@@ -84,6 +86,7 @@ export default function MenuDetail({
 
   const handleClickAddToCart = () => {
     dispatch(requestAddToCart());
+    navigate('/cart');
   };
 
   const handleClickPlusOne = () => {

--- a/src/MenuDetail.jsx
+++ b/src/MenuDetail.jsx
@@ -2,8 +2,6 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { useEffect } from 'react';
 
-import { useNavigate } from 'react-router-dom';
-
 import styled from '@emotion/styled';
 
 import { BsFillDashCircleFill, BsPlusCircleFill } from 'react-icons/bs';
@@ -77,7 +75,6 @@ export default function MenuDetail({
   },
 }) {
   const dispatch = useDispatch();
-  const navigate = useNavigate();
 
   const menuQuantity = useSelector((state) => state.menuQuantity);
 
@@ -87,7 +84,6 @@ export default function MenuDetail({
 
   const handleClickAddToCart = () => {
     dispatch(requestAddToCart());
-    navigate('/cart');
   };
 
   const handleClickPlusOne = () => {
@@ -123,7 +119,6 @@ export default function MenuDetail({
       </MenuQuantity>
       <OrderButton>주문하기</OrderButton>
       <CartButton onClick={handleClickAddToCart}>장바구니에 담기</CartButton>
-
     </>
   );
 }

--- a/src/MenuDetail.jsx
+++ b/src/MenuDetail.jsx
@@ -2,11 +2,15 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { useEffect } from 'react';
 
+import { useNavigate } from 'react-router-dom';
+
 import styled from '@emotion/styled';
 
 import { BsFillDashCircleFill, BsPlusCircleFill } from 'react-icons/bs';
 
-import { initializeMenuQuantity, menuQuantityMinusOne, menuQuantityPlusOne } from './store';
+import {
+  initializeMenuQuantity, menuQuantityMinusOne, menuQuantityPlusOne, requestAddToCart,
+} from './store';
 
 const MenuImage = styled.div(
   ({ url }) => ({
@@ -73,6 +77,7 @@ export default function MenuDetail({
   },
 }) {
   const dispatch = useDispatch();
+  const navigate = useNavigate();
 
   const menuQuantity = useSelector((state) => state.menuQuantity);
 
@@ -81,7 +86,8 @@ export default function MenuDetail({
   }, []);
 
   const handleClickAddToCart = () => {
-    // TODO : 클릭한 메뉴를 장바구니에 담는 api 호출하기
+    dispatch(requestAddToCart());
+    navigate('/cart');
   };
 
   const handleClickPlusOne = () => {

--- a/src/MenuDetail.jsx
+++ b/src/MenuDetail.jsx
@@ -1,10 +1,12 @@
 import { useDispatch, useSelector } from 'react-redux';
 
+import { useEffect } from 'react';
+
 import styled from '@emotion/styled';
 
 import { BsFillDashCircleFill, BsPlusCircleFill } from 'react-icons/bs';
 
-import { menuQuantityMinusOne, menuQuantityPlusOne } from './store';
+import { initializeMenuQuantity, menuQuantityMinusOne, menuQuantityPlusOne } from './store';
 
 const MenuImage = styled.div(
   ({ url }) => ({
@@ -73,6 +75,10 @@ export default function MenuDetail({
   const dispatch = useDispatch();
 
   const menuQuantity = useSelector((state) => state.menuQuantity);
+
+  useEffect(() => {
+    dispatch(initializeMenuQuantity());
+  }, []);
 
   const handleClickAddToCart = () => {
     // TODO : 클릭한 메뉴를 장바구니에 담는 api 호출하기

--- a/src/MenuDetail.jsx
+++ b/src/MenuDetail.jsx
@@ -1,6 +1,10 @@
+import { useDispatch, useSelector } from 'react-redux';
+
 import styled from '@emotion/styled';
 
 import { BsFillDashCircleFill, BsPlusCircleFill } from 'react-icons/bs';
+
+import { menuQuantityMinusOne, menuQuantityPlusOne } from './store';
 
 const MenuImage = styled.div(
   ({ url }) => ({
@@ -66,19 +70,20 @@ export default function MenuDetail({
     description, englishName, imagePath, name, price,
   },
 }) {
+  const dispatch = useDispatch();
+
+  const menuQuantity = useSelector((state) => state.menuQuantity);
+
   const handleClickAddToCart = () => {
     // TODO : 클릭한 메뉴를 장바구니에 담는 api 호출하기
-
   };
 
   const handleClickPlusOne = () => {
-    // TODO : 메뉴 수량 +1
-    alert('handleClickPlusOne');
+    dispatch(menuQuantityPlusOne());
   };
 
   const handleClickMinusOne = () => {
-    // TODO : 메뉴 수량 -1
-    alert('handleClickMinusOne');
+    dispatch(menuQuantityMinusOne());
   };
 
   return (
@@ -101,7 +106,7 @@ export default function MenuDetail({
       </MenuPrice>
       <MenuQuantity>
         <BsFillDashCircleFill size="30" onClick={handleClickMinusOne} />
-        <Quantity>1</Quantity>
+        <Quantity>{menuQuantity}</Quantity>
         <BsPlusCircleFill size="30" onClick={handleClickPlusOne} />
       </MenuQuantity>
       <OrderButton>주문하기</OrderButton>

--- a/src/SignContainer.jsx
+++ b/src/SignContainer.jsx
@@ -4,6 +4,7 @@ import { Link, useNavigate } from 'react-router-dom';
 
 import styled from '@emotion/styled';
 
+import { TiShoppingCart } from 'react-icons/ti';
 import { clearLoginFields, logout } from './store';
 
 const List = styled.ul({
@@ -22,6 +23,9 @@ const Item = styled.li({
   '& a': {
     color: '#555555',
     textDecoration: 'none',
+    display: 'flex',
+    alignItems: 'center',
+    lineHeight: '1.5rem',
   },
 });
 
@@ -52,7 +56,10 @@ export default function SignContainer() {
         {
           accessToken ? (
             <Item>
-              <Link to="/cart">Cart</Link>
+              <Link to="/cart">
+                Cart
+                <TiShoppingCart size="1.5rem" />
+              </Link>
             </Item>
           ) : null
         }

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,3 @@
 export const DEFAULT_SELECTED_CATEGORY_IS_NONE = 0;
 
-export const DELETE_IT = 0; // TODO : export default 를 막기 위해 적은 임시 변수 (나중에 지우세요.)
+export const CURRENT_PAGE_RELOAD = 0;

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -80,8 +80,8 @@ export async function postAddToCart({ accessToken, menuId, quantity }) {
       quantity,
     }),
   });
-  const data = await response.json();
-  return data;
+
+  return response.status;
 }
 
 export async function postOrder({ accessToken, checkedCartItems }) {
@@ -126,6 +126,5 @@ export async function deleteCartItem({ accessToken, menuId }) {
     },
   });
 
-  const responseData = await response;
-  return responseData.status;
+  return response.status;
 }

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -128,3 +128,32 @@ export async function deleteCartItem({ accessToken, menuId }) {
 
   return response.status;
 }
+
+export async function deleteSelectedCartItems({ accessToken, checkedCartItems }) {
+  const url = `${BASE_URL}/cart/cart-menus/`;
+  const response = await fetch(url, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({
+      cartMenuIds: checkedCartItems,
+    }),
+  });
+
+  return response.status;
+}
+
+export async function deleteAllCartItems({ accessToken }) {
+  const url = `${BASE_URL}/cart/cart-menus/all`;
+  const response = await fetch(url, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  return response.status;
+}

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -126,6 +126,6 @@ export async function deleteCartItem({ accessToken, menuId }) {
     },
   });
 
-  const data = await response.json();
-  return data;
+  const responseData = await response;
+  return responseData.status;
 }

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -115,3 +115,17 @@ export async function patchCartItemQuantity({ accessToken, menuId, quantity }) {
   const data = await response.json();
   return data;
 }
+
+export async function deleteCartItem({ accessToken, menuId }) {
+  const url = `${BASE_URL}/cart/cart-menus/${menuId}`;
+  const response = await fetch(url, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  const data = await response.json();
+  return data;
+}

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -67,6 +67,23 @@ export async function postLogin({ email, password }) {
   return accessToken;
 }
 
+export async function postAddToCart({ accessToken, menuId, quantity }) {
+  const url = `${BASE_URL}/cart/cart-menus`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({
+      menuId,
+      quantity,
+    }),
+  });
+  const data = await response.json();
+  return data;
+}
+
 export async function postOrder({ accessToken, checkedCartItems }) {
   const url = `${BASE_URL}/cart/order`;
   const response = await fetch(url, {

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -100,3 +100,18 @@ export async function postOrder({ accessToken, checkedCartItems }) {
   const data = await response.json();
   return data;
 }
+
+export async function patchCartItemQuantity({ accessToken, menuId, quantity }) {
+  const url = `${BASE_URL}/cart/cart-menus/${menuId}`;
+  const response = await fetch(url, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({ quantity }),
+  });
+
+  const data = await response.json();
+  return data;
+}

--- a/src/store.js
+++ b/src/store.js
@@ -461,6 +461,10 @@ function reducer(state = initialState, action = {}) {
       ...state,
       cartMenus: state.cartMenus.map((menu) => {
         if (menu.id === menuId) {
+          if ((menu.quantity - 1) < 1) {
+            alert('수량은 1보다 작을 수 없습니다.');
+            return menu;
+          }
           return ({ ...menu, quantity: menu.quantity - 1 });
         }
         return menu;

--- a/src/store.js
+++ b/src/store.js
@@ -281,7 +281,7 @@ export function requestAddToCart() {
       const responseStatus = await postAddToCart({ accessToken, menuId, quantity: menuQuantity });
 
       if (responseStatus === 201) {
-        dispatch(loadCart());
+        alert('메뉴를 장바구니에 담았습니다.');
       }
     } catch (err) {
       // TODO : 에러 처리

--- a/src/store.js
+++ b/src/store.js
@@ -7,7 +7,9 @@ import thunk from 'redux-thunk';
 import { logger } from 'redux-logger';
 
 import {
+  deleteAllCartItems,
   deleteCartItem,
+  deleteSelectedCartItems,
   fetchCart,
   fetchCategories,
   fetchMenu,
@@ -329,6 +331,40 @@ export function requestRemoveCartItem(menuId) {
 
       if (responseStatus === 204) {
         alert('메뉴를 삭제했습니다.');
+        dispatch(loadCart());
+      }
+    } catch (err) {
+      // TODO : 에러 처리
+    }
+  };
+}
+
+export function requestDeleteSelectedCartItem() {
+  return async (dispatch, getState) => {
+    const { accessToken, checkedCartItems } = getState();
+
+    try {
+      const responseStatus = await deleteSelectedCartItems({ accessToken, checkedCartItems });
+
+      if (responseStatus === 204) {
+        alert('선택한 메뉴를 삭제했습니다.');
+        dispatch(loadCart());
+      }
+    } catch (err) {
+      // TODO : 에러 처리
+    }
+  };
+}
+
+export function requestDeleteAllCartItems() {
+  return async (dispatch, getState) => {
+    const { accessToken } = getState();
+
+    try {
+      const responseStatus = await deleteAllCartItems({ accessToken });
+
+      if (responseStatus === 204) {
+        alert('전체 메뉴를 삭제했습니다.');
         dispatch(loadCart());
       }
     } catch (err) {

--- a/src/store.js
+++ b/src/store.js
@@ -21,6 +21,7 @@ const initialState = {
   menuGroups: [],
   menus: [],
   menu: {},
+  menuQuantity: 1,
   selectedCategory: DEFAULT_SELECTED_CATEGORY_IS_NONE,
   loginFields: {
     email: '',
@@ -54,6 +55,9 @@ const SET_CART_MENUS = 'SET_CART_MENUS';
 const ADD_CHECKED_CART_ITEM = 'ADD_CHECKED_CART_ITEM';
 const REMOVE_UNCHECKED_CART_ITEM = 'REMOVE_UNCHECKED_CART_ITEM';
 const CLEAR_CHECKED_CART_ITEMS = 'CLEAR_CHECKED_CART_ITEMS';
+const MENU_QUANTITY_PLUS_ONE = 'MENU_QUANTITY_PLUS_ONE';
+const MENU_QUANTITY_MINUS_ONE = 'MENU_QUANTITY_MINUS_ONE';
+const INITIALIZE_MENU_QUANTITY = 'INITIALIZE_MENU_QUANTITY';
 
 export function updateLoginFields({ name, value }) {
   return {
@@ -240,6 +244,24 @@ export function requestOrder() {
   };
 }
 
+export function menuQuantityPlusOne() {
+  return {
+    type: MENU_QUANTITY_PLUS_ONE,
+  };
+}
+
+export function menuQuantityMinusOne() {
+  return {
+    type: MENU_QUANTITY_MINUS_ONE,
+  };
+}
+
+export function initializeMenuQuantity() {
+  return {
+    type: INITIALIZE_MENU_QUANTITY,
+  };
+}
+
 // - 리듀서
 function reducer(state = initialState, action = {}) {
   if (action.type === UPDATE_LOGIN_FIELDS) {
@@ -354,6 +376,27 @@ function reducer(state = initialState, action = {}) {
     return {
       ...state,
       checkedCartItems: [],
+    };
+  }
+
+  if (action.type === MENU_QUANTITY_PLUS_ONE) {
+    return {
+      ...state,
+      menuQuantity: state.menuQuantity + 1,
+    };
+  }
+
+  if (action.type === MENU_QUANTITY_MINUS_ONE) {
+    return {
+      ...state,
+      menuQuantity: state.menuQuantity - 1,
+    };
+  }
+
+  if (action.type === INITIALIZE_MENU_QUANTITY) {
+    return {
+      ...state,
+      menuQuantity: 1,
     };
   }
 

--- a/src/store.js
+++ b/src/store.js
@@ -58,6 +58,8 @@ const CLEAR_CHECKED_CART_ITEMS = 'CLEAR_CHECKED_CART_ITEMS';
 const MENU_QUANTITY_PLUS_ONE = 'MENU_QUANTITY_PLUS_ONE';
 const MENU_QUANTITY_MINUS_ONE = 'MENU_QUANTITY_MINUS_ONE';
 const INITIALIZE_MENU_QUANTITY = 'INITIALIZE_MENU_QUANTITY';
+const CART_MENU_QUANTITY_PLUS_ONE = 'CART_MENU_QUANTITY_PLUS_ONE';
+const CART_MENU_QUANTITY_MINUS_ONE = 'CART_MENU_QUANTITY_MINUS_ONE';
 
 export function updateLoginFields({ name, value }) {
   return {
@@ -274,6 +276,20 @@ export function requestAddToCart() {
   };
 }
 
+export function cartMenuQuantityPlusOne(menuId) {
+  return {
+    type: CART_MENU_QUANTITY_PLUS_ONE,
+    payload: { menuId },
+  };
+}
+
+export function cartMenuQuantityMinusOne(menuId) {
+  return {
+    type: CART_MENU_QUANTITY_MINUS_ONE,
+    payload: { menuId },
+  };
+}
+
 // - 리듀서
 function reducer(state = initialState, action = {}) {
   if (action.type === UPDATE_LOGIN_FIELDS) {
@@ -409,6 +425,32 @@ function reducer(state = initialState, action = {}) {
     return {
       ...state,
       menuQuantity: 1,
+    };
+  }
+
+  if (action.type === CART_MENU_QUANTITY_PLUS_ONE) {
+    const { menuId } = action.payload;
+    return {
+      ...state,
+      cartMenus: state.cartMenus.map((menu) => {
+        if (menu.id === menuId) {
+          return ({ ...menu, quantity: menu.quantity + 1 });
+        }
+        return menu;
+      }),
+    };
+  }
+
+  if (action.type === CART_MENU_QUANTITY_MINUS_ONE) {
+    const { menuId } = action.payload;
+    return {
+      ...state,
+      cartMenus: state.cartMenus.map((menu) => {
+        if (menu.id === menuId) {
+          return ({ ...menu, quantity: menu.quantity - 1 });
+        }
+        return menu;
+      }),
     };
   }
 

--- a/src/store.js
+++ b/src/store.js
@@ -7,8 +7,16 @@ import thunk from 'redux-thunk';
 import { logger } from 'redux-logger';
 
 import {
-  fetchCart, fetchCategories, fetchMenu, fetchMenuGroups, fetchMenus,
-  postLogin, postSignUp, postAddToCart, postOrder, patchCartItemQuantity,
+  fetchCart,
+  fetchCategories,
+  fetchMenu,
+  fetchMenuGroups,
+  fetchMenus,
+  patchCartItemQuantity,
+  postAddToCart,
+  postLogin,
+  postOrder,
+  postSignUp,
 } from './services/api';
 
 import { saveItem } from './services/localStorage';
@@ -297,7 +305,10 @@ export function requestUpdateCartItemQuantity(menuId) {
     const { quantity } = cartMenus.find((item) => item.id === menuId);
 
     try {
-      await patchCartItemQuantity({ accessToken, menuId, quantity });
+      const data = await patchCartItemQuantity({ accessToken, menuId, quantity });
+      if (data) {
+        alert('수량을 변경하였습니다.');
+      }
     } catch (err) {
       // TODO : 에러 처리
     }

--- a/src/store.js
+++ b/src/store.js
@@ -278,7 +278,11 @@ export function requestAddToCart() {
     const { accessToken, menu: { id: menuId }, menuQuantity } = getState();
 
     try {
-      await postAddToCart({ accessToken, menuId, quantity: menuQuantity });
+      const responseStatus = await postAddToCart({ accessToken, menuId, quantity: menuQuantity });
+
+      if (responseStatus === 201) {
+        dispatch(loadCart());
+      }
     } catch (err) {
       // TODO : 에러 처리
     }

--- a/src/store.js
+++ b/src/store.js
@@ -7,6 +7,7 @@ import thunk from 'redux-thunk';
 import { logger } from 'redux-logger';
 
 import {
+  deleteCartItem,
   fetchCart,
   fetchCategories,
   fetchMenu,
@@ -309,6 +310,18 @@ export function requestUpdateCartItemQuantity(menuId) {
       if (data) {
         alert('수량을 변경하였습니다.');
       }
+    } catch (err) {
+      // TODO : 에러 처리
+    }
+  };
+}
+
+export function requestRemoveCartItem(menuId) {
+  return async (dispatch, getState) => {
+    const { accessToken } = getState();
+
+    try {
+      await deleteCartItem({ accessToken, menuId });
     } catch (err) {
       // TODO : 에러 처리
     }

--- a/src/store.js
+++ b/src/store.js
@@ -8,7 +8,7 @@ import { logger } from 'redux-logger';
 
 import {
   fetchCart, fetchCategories, fetchMenu, fetchMenuGroups, fetchMenus,
-  postLogin, postOrder, postSignUp,
+  postLogin, postSignUp, postAddToCart, postOrder,
 } from './services/api';
 
 import { saveItem } from './services/localStorage';
@@ -259,6 +259,18 @@ export function menuQuantityMinusOne() {
 export function initializeMenuQuantity() {
   return {
     type: INITIALIZE_MENU_QUANTITY,
+  };
+}
+
+export function requestAddToCart() {
+  return async (dispatch, getState) => {
+    const { accessToken, menu: { id: menuId }, menuQuantity } = getState();
+
+    try {
+      await postAddToCart({ accessToken, menuId, quantity: menuQuantity });
+    } catch (err) {
+      // TODO : 에러 처리
+    }
   };
 }
 

--- a/src/store.js
+++ b/src/store.js
@@ -8,7 +8,7 @@ import { logger } from 'redux-logger';
 
 import {
   fetchCart, fetchCategories, fetchMenu, fetchMenuGroups, fetchMenus,
-  postLogin, postSignUp, postAddToCart, postOrder,
+  postLogin, postSignUp, postAddToCart, postOrder, patchCartItemQuantity,
 } from './services/api';
 
 import { saveItem } from './services/localStorage';
@@ -287,6 +287,20 @@ export function cartMenuQuantityMinusOne(menuId) {
   return {
     type: CART_MENU_QUANTITY_MINUS_ONE,
     payload: { menuId },
+  };
+}
+
+export function requestUpdateCartItemQuantity(menuId) {
+  return async (dispatch, getState) => {
+    const { accessToken, cartMenus } = getState();
+
+    const { quantity } = cartMenus.find((item) => item.id === menuId);
+
+    try {
+      await patchCartItemQuantity({ accessToken, menuId, quantity });
+    } catch (err) {
+      // TODO : 에러 처리
+    }
   };
 }
 

--- a/src/store.js
+++ b/src/store.js
@@ -321,7 +321,12 @@ export function requestRemoveCartItem(menuId) {
     const { accessToken } = getState();
 
     try {
-      await deleteCartItem({ accessToken, menuId });
+      const responseStatus = await deleteCartItem({ accessToken, menuId });
+
+      if (responseStatus === 204) {
+        alert('메뉴를 삭제했습니다.');
+        dispatch(loadCart());
+      }
     } catch (err) {
       // TODO : 에러 처리
     }


### PR DESCRIPTION
## 작업 내역
- 장바구니 담기 버튼을 생성한다.
- 수량 조절 버튼을 생성한다.
- 메뉴 화면 렌더링 시, 주문할 수량을 1로 초기화한다.
- 상세 메뉴 화면에서 해당 메뉴를 장바구니에 담을 수 있다.
- 장바구니가 비어있으면 사용자에게 안내한다.
- 장바구니에서 특정 메뉴의 수량을 변경할 수 있다.
- 장바구니에서 특정 메뉴를 삭제할 수 있다.
- 장바구니에서 선택한 메뉴들을 삭제할 수 있다.
- 장바구니에서 전체 메뉴를 삭제할 수 있다.
- 장바구니에서 주문할 메뉴를 선택하면 총 수량과 결제할 금액을 계산하여 보여준다.
