### PR TITLE
[리팩토링] 각 컴포넌트의 <Route> path를 간결하게 표현한다.

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -79,9 +79,9 @@ export default function App() {
             <Route path="/login" element={<LoginPage />} />
             <Route path="/signUp" element={<SignUpContainer />} />
             <Route path="/cart" element={<CartContainer />} />
-            <Route path="/categories/:categoryId/menu-groups" element={<MenuGroupContainer />} />
+            <Route path="/categories/:categoryId" element={<MenuGroupContainer />} />
             <Route path="/menu-groups/:menuGroupId" element={<MenuListContainer />} />
-            <Route path="/menu-groups/:menuGroupId/menus/:menuId" element={<MenuDetailContainer />} />
+            <Route path="/menus/:menuId" element={<MenuDetailContainer />} />
           </Routes>
         </ContentContainer>
       </Container>

--- a/src/CategoryContainer.jsx
+++ b/src/CategoryContainer.jsx
@@ -53,7 +53,7 @@ export default function CategoryContainer() {
       {
         categories.map(({ id, name }) => (
           <Category key={id} active={selectedCategory === id}>
-            <Link to={`/categories/${id}/menu-groups`} state={{ categoryId: id }}>
+            <Link to={`/categories/${id}`} state={{ categoryId: id }}>
               {name}
             </Link>
           </Category>

--- a/src/MenuList.jsx
+++ b/src/MenuList.jsx
@@ -35,7 +35,7 @@ const NoMenu = styled.h1({
   fontSize: '2rem',
 });
 
-export default function MenuList({ menus, menuGroupId, selectedCategory }) {
+export default function MenuList({ menus, selectedCategory }) {
   if (menus === undefined) {
     return (
       <MenuList>
@@ -50,7 +50,7 @@ export default function MenuList({ menus, menuGroupId, selectedCategory }) {
         menus.map(({ id, imagePath, name }) => (
           <Menu key={name}>
             <MenuImage>
-              <Link to={`/menu-groups/${menuGroupId}/menus/${id}`} state={{ categoryId: selectedCategory }}>
+              <Link to={`/menus/${id}`} state={{ categoryId: selectedCategory }}>
                 <img src={`https://coffee-and-taste.kro.kr${imagePath}`} alt={name} />
               </Link>
             </MenuImage>

--- a/src/MenuListContainer.jsx
+++ b/src/MenuListContainer.jsx
@@ -32,7 +32,7 @@ export default function MenuListContainer() {
 
   return (
     <MenuContainerStyle>
-      <MenuList menus={menus} menuGroupId={menuGroupId} selectedCategory={selectedCategory} />
+      <MenuList menus={menus} selectedCategory={selectedCategory} />
     </MenuContainerStyle>
   );
 }


### PR DESCRIPTION
### 변경 전
이전에는 특정 메뉴를 조회할 때의 URL path가  ~/menu-groups/`:menuGroupId`/menus/`:menuId` 처럼
불필요한 params(=`menuGroupId`) 가 포함됐다.

<hr />

### 변경 후
각 컴포넌트의 Route path 에서 불필요한 params 를 줄이고 간결하게 표현한다.
- 카테고리: ~/category/`:categoryId`
- 메뉴 그룹 : ~/menu-groups/`:menuGroupId`
- 특정 메뉴 : ~/menus/`:menuId`