### PR TITLE
Safari 브라우저에서 메뉴 이미지 hover 이벤트 동작 오류 수정

### DIFF
--- a/src/MenuDetail.jsx
+++ b/src/MenuDetail.jsx
@@ -8,6 +8,7 @@ const MenuImage = styled.div({
   margin: '30px auto',
   overflow: 'hidden',
   borderRadius: '50%',
+  isolation: 'isolate',
   '& img': {
     width: '100%',
     height: '100%',

--- a/src/MenuGroup.jsx
+++ b/src/MenuGroup.jsx
@@ -14,6 +14,7 @@ const MenuGroupImage = styled.div({
   margin: '50px auto 30px auto',
   overflow: 'hidden',
   borderRadius: '50%',
+  isolation: 'isolate',
   '& img': {
     width: '100%',
     height: '100%',

--- a/src/MenuList.jsx
+++ b/src/MenuList.jsx
@@ -11,6 +11,7 @@ const MenuImage = styled.div({
   margin: '50px auto 20px auto',
   overflow: 'hidden',
   borderRadius: '50%',
+  isolation: 'isolate',
   '& img': {
     width: '100%',
     height: '100%',


### PR DESCRIPTION
### 관련 이슈
- #29 

<hr />

### 작업 내역
- 이미지를 감싼 태그에 `isolation: 'isolate'` 속성 추가

