### PR TITLE
`:first-child` 대신 `:first-of-type` 을 적용한다.

### DIFF
--- a/src/SignContainer.jsx
+++ b/src/SignContainer.jsx
@@ -30,7 +30,7 @@ const Item = styled.li({
   minWidth: '6rem',
   padding: '0 .5rem',
   borderLeft: '3px solid #321414',
-  '&:first-child': {
+  '&:first-of-type': {
     borderLeft: 'none',
   },
   '& a': {


### PR DESCRIPTION
### 현상
- `:first-child` 선택자를 적용한 코드가 있는데 웹 브라우저에서 이에 대해 경고한다.

  ![image](https://user-images.githubusercontent.com/55405713/177688727-c059b787-80aa-44c4-bc5d-b4494c974c71.png)
